### PR TITLE
perf: decrease run time by ~40% by avoiding allocations in hot loop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,5 @@ leb128 = "0.2.5"
 proptest = "1.x"
 proptest-derive = "0.5"
 
+[profile.release]
+debug = true

--- a/examples/read.rs
+++ b/examples/read.rs
@@ -1,0 +1,32 @@
+use fst_reader::FstReader;
+
+fn main() {
+    let input_path = std::env::args_os()
+        .nth(1)
+        .expect("missing input file argument");
+
+    let input = std::fs::File::open(input_path).expect("failed to open input file!");
+
+    let mut reader = FstReader::open(std::io::BufReader::new(input)).unwrap();
+
+    let _header = reader.get_header();
+
+    let mut ids = Vec::new();
+
+    reader
+        .read_hierarchy(|entry| match entry {
+            fst_reader::FstHierarchyEntry::Var { handle, .. } => ids.push(handle),
+            fst_reader::FstHierarchyEntry::Scope { .. } => {}
+            fst_reader::FstHierarchyEntry::UpScope { .. } => {}
+            _ => {}
+        })
+        .unwrap();
+
+    let filter = fst_reader::FstFilter::new(0, u64::MAX, ids);
+
+    reader
+        .read_signals(&filter, |time_idx, handle, value| {
+            std::hint::black_box((time_idx, handle, value));
+        })
+        .unwrap();
+}

--- a/src/io.rs
+++ b/src/io.rs
@@ -282,15 +282,14 @@ pub(crate) fn one_bit_signal_value_to_char(vli: u32) -> u8 {
 
 /// Decodes a digital (1/0) signal. This is indicated by bit0 in vli being cleared.
 #[inline]
-pub(crate) fn multi_bit_digital_signal_to_chars(bytes: &[u8], len: usize) -> Vec<u8> {
-    let mut chars = Vec::with_capacity(len);
-    for ii in 0..len {
+pub(crate) fn multi_bit_digital_signal_to_chars(bytes: &[u8], len: usize, output: &mut Vec<u8>) {
+    output.resize(len, 0);
+    for (ii, out) in output.iter_mut().enumerate() {
         let byte_id = ii / 8;
         let bit_id = 7 - (ii & 7);
         let bit = (bytes[byte_id] >> bit_id) & 1;
-        chars.push(bit | b'0');
+        *out = bit | b'0';
     }
-    chars
 }
 
 pub(crate) fn read_one_bit_signal_time_delta(bytes: &[u8], offset: u32) -> ReadResult<usize> {


### PR DESCRIPTION
While bench marking `2fst` I notice that a lot of time is spend allocating and de-allocating `Vec`s in `read_value_changes`. I avoided those allocations getting slices from `mu_slice`, instead of reading it to a new `Vec`, and by adding a reusable buffer for `multi_bit_digital_signal_to_chars`.

I added a new example for making the speed measurements. The only `.fst` file with a reasonable size I have is the one I got from running `vcd2fst` on `trace.vcd`, not sure how representative it is.

[trace.zip](https://github.com/user-attachments/files/18231536/trace.zip)

```
> hyperfine './read-6ec01e3 trace.fst' './read-f162357 trace.fst'
Benchmark 1: ./read-6ec01e3 trace.fst
  Time (mean ± σ):      1.191 s ±  0.029 s    [User: 1.127 s, System: 0.059 s]
  Range (min … max):    1.151 s …  1.235 s    10 runs

Benchmark 2: ./read-f162357 trace.fst
  Time (mean ± σ):     672.5 ms ±  10.4 ms    [User: 611.5 ms, System: 56.9 ms]
  Range (min … max):   653.5 ms … 689.6 ms    10 runs

Summary
  ./read-f162357 trace.fst ran
    1.77 ± 0.05 times faster than ./read-6ec01e3 trace.fst
```