### PR TITLE
Add documentation for `FstFilter`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 authors = ["Kevin Laeufer <laeufer@cornell.edu>"]
 description = "FST wavedump format reader implemented in safe Rust. Formerly known as fst-native."
 homepage = "https://github.com/ekiwi/fst-reader"
+repository = "https://github.com/ekiwi/fst-reader"
 license = "BSD-3-Clause"
 include = ["Cargo.toml", "LICENSE", "src/", "tests/", "examples/"]
 keywords = ["fst", "waveform", "wavedump"]

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -19,6 +19,9 @@ enum InputVariant<R: BufRead + Seek> {
     UncompressedInMem(std::io::Cursor<Vec<u8>>),
 }
 
+/// Filter the changes by time and/or signals
+/// 
+/// The time filter is inclusive, i.e. it includes all changes in `start..=end`.
 pub struct FstFilter {
     pub start: u64,
     pub end: Option<u64>,


### PR DESCRIPTION
Thanks for writing this very useful crate!

I've added documentation to `FstFilter` to document that the time filter is inclusive (`start..=end`).
In addition, I added a repository link in `Cargo.toml` which allows [docs.rs](https://docs.rs), [crates.io](https://crates.io) and other sites to link to the repo.

Feel free to cherry pick.