### PR TITLE
Add support for incomplete FST files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fst-reader"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 authors = ["Kevin Laeufer <laeufer@cornell.edu>"]
 description = "FST wavedump format reader implemented in safe Rust. Formerly known as fst-native."

--- a/src/io.rs
+++ b/src/io.rs
@@ -1282,7 +1282,7 @@ impl From<Vec<SignalDataLoc>> for OffsetTable {
 }
 
 impl OffsetTable {
-    pub(crate) fn iter(&self) -> OffsetTableIter {
+    pub(crate) fn iter(&self) -> OffsetTableIter<'_> {
         OffsetTableIter {
             table: self,
             signal_idx: 0,

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -8,15 +8,17 @@ use crate::types::*;
 use std::io::{BufRead, Read, Seek, SeekFrom, Write};
 
 /// Reads in a FST file.
-pub struct FstReader<R: BufRead + Seek> {
-    input: InputVariant<R>,
+pub struct FstReader<R: BufRead + Seek, H = std::io::Cursor<Vec<u8>>> {
+    input: InputVariant<R, H>,
     meta: MetaData,
 }
 
-enum InputVariant<R: BufRead + Seek> {
+enum InputVariant<R: BufRead + Seek, H = std::io::Cursor<Vec<u8>>> {
     Original(R),
+    Incomplete(R, H),
     // Uncompressed(BufReader<std::fs::File>),
     UncompressedInMem(std::io::Cursor<Vec<u8>>),
+    IncompleteUncompressedInMem(std::io::Cursor<Vec<u8>>, H),
 }
 
 /// Filter the changes by time and/or signals
@@ -80,6 +82,67 @@ pub struct FstHeader {
     pub timescale_exponent: i8,
 }
 
+impl<R: BufRead + Seek, H: BufRead + Seek> FstReader<R, H> {
+    pub fn open_incomplete(input: R, hierarchy: H) -> Result<Self> {
+        Self::open_incomplete_internal(input, hierarchy, false)
+    }
+
+    pub fn open_incomplete_and_read_time_table(input: R, hierarchy: H) -> Result<Self> {
+        Self::open_incomplete_internal(input, hierarchy, true)
+    }
+
+    fn open_incomplete_internal(
+        mut input: R,
+        mut hierarchy: H,
+        read_time_table: bool,
+    ) -> Result<Self> {
+        let uncompressed_input = uncompress_gzip_wrapper(&mut input)?;
+        match uncompressed_input {
+            UncompressGzipWrapper::None => {
+                let (input, meta) = Self::open_incomplete_internal_uncompressed(
+                    input,
+                    &mut hierarchy,
+                    read_time_table,
+                )?;
+                Ok(FstReader {
+                    input: InputVariant::Incomplete(input, hierarchy),
+                    meta,
+                })
+            }
+            UncompressGzipWrapper::InMemory(uc) => {
+                let (uc2, meta) = Self::open_incomplete_internal_uncompressed(
+                    uc,
+                    &mut hierarchy,
+                    read_time_table,
+                )?;
+                Ok(FstReader {
+                    input: InputVariant::IncompleteUncompressedInMem(uc2, hierarchy),
+                    meta,
+                })
+            }
+        }
+    }
+
+    fn open_incomplete_internal_uncompressed<I: BufRead + Seek>(
+        input: I,
+        hierarchy: &mut H,
+        read_time_table: bool,
+    ) -> Result<(I, MetaData)> {
+        let mut header_reader = HeaderReader::new(input);
+        match header_reader.read(read_time_table) {
+            Ok(_) => {}
+            Err(ReaderError::MissingGeometry() | ReaderError::MissingHierarchy()) => {
+                header_reader
+                    .hierarchy
+                    .get_or_insert((HierarchyCompression::Uncompressed, 0));
+                header_reader.reconstruct_geometry(hierarchy)?;
+            }
+            Err(e) => return Err(e),
+        };
+        Ok(header_reader.into_input_and_meta_data().unwrap())
+    }
+}
+
 impl<R: BufRead + Seek> FstReader<R> {
     /// Reads in the FST file meta-data.
     pub fn open(input: R) -> Result<Self> {
@@ -113,7 +176,9 @@ impl<R: BufRead + Seek> FstReader<R> {
             }
         }
     }
+}
 
+impl<R: BufRead + Seek, H: BufRead + Seek> FstReader<R, H> {
     pub fn get_header(&self) -> FstHeader {
         FstHeader {
             start_time: self.meta.header.start_time,
@@ -137,7 +202,11 @@ impl<R: BufRead + Seek> FstReader<R> {
     pub fn read_hierarchy(&mut self, callback: impl FnMut(FstHierarchyEntry)) -> Result<()> {
         match &mut self.input {
             InputVariant::Original(input) => read_hierarchy(input, &self.meta, callback),
+            InputVariant::Incomplete(_, input) => read_hierarchy(input, &self.meta, callback),
             InputVariant::UncompressedInMem(input) => read_hierarchy(input, &self.meta, callback),
+            InputVariant::IncompleteUncompressedInMem(_, input) => {
+                read_hierarchy(input, &self.meta, callback)
+            }
         }
     }
 
@@ -171,7 +240,13 @@ impl<R: BufRead + Seek> FstReader<R> {
             InputVariant::Original(input) => {
                 read_signals(input, &self.meta, &data_filter, callback)
             }
+            InputVariant::Incomplete(input, _) => {
+                read_signals(input, &self.meta, &data_filter, callback)
+            }
             InputVariant::UncompressedInMem(input) => {
+                read_signals(input, &self.meta, &data_filter, callback)
+            }
+            InputVariant::IncompleteUncompressedInMem(input, _) => {
                 read_signals(input, &self.meta, &data_filter, callback)
             }
         }
@@ -413,6 +488,23 @@ impl<R: Read + Seek> HeaderReader<R> {
             kind,
             mem_required_for_traversal,
         };
+
+        // incomplete fst files may have start_time and end_time set to 0,
+        // in which case we can infer it from the data
+        if let Some(Header {
+            start_time: header_start,
+            end_time: header_end,
+            ..
+        }) = self.header.as_mut()
+        {
+            if *header_start == 0 && *header_end == 0 {
+                *header_end = end_time;
+                if self.data_sections.is_empty() {
+                    *header_start = start_time;
+                }
+            }
+        }
+
         self.data_sections.push(info);
         Ok(())
     }
@@ -433,6 +525,27 @@ impl<R: Read + Seek> HeaderReader<R> {
             "Only a single hierarchy block is expected!"
         );
         self.hierarchy = Some((compression, file_offset));
+        Ok(())
+    }
+
+    fn reconstruct_geometry(&mut self, hierarchy: &mut (impl BufRead + Seek)) -> Result<()> {
+        hierarchy.seek(SeekFrom::Start(0))?;
+        let bytes = read_hierarchy_bytes(hierarchy, HierarchyCompression::Uncompressed)?;
+        let mut input = bytes.as_slice();
+        let mut handle_count = 0u32;
+        let mut signals: Vec<SignalInfo> = Vec::new();
+        while let Some(entry) = read_hierarchy_entry(&mut input, &mut handle_count)? {
+            match entry {
+                FstHierarchyEntry::Var {
+                    length, is_alias, ..
+                } if !is_alias => {
+                    // dbg!(&entry);
+                    signals.push(SignalInfo::from_file_format(length));
+                }
+                _ => {}
+            }
+        }
+        self.signals = Some(signals);
         Ok(())
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -348,6 +348,7 @@ pub enum FstHierarchyEntry {
 #[derive(Debug, Copy, Clone)]
 #[cfg_attr(test, derive(Arbitrary))]
 pub(crate) enum HierarchyCompression {
+    Uncompressed,
     ZLib,
     Lz4,
     Lz4Duo,

--- a/tests/fst_reader_tests.rs
+++ b/tests/fst_reader_tests.rs
@@ -7,6 +7,7 @@
 // and thus we cannot compare.
 
 use fst_reader::*;
+use std::collections::binary_heap::Iter;
 use std::io::{BufRead, Seek};
 use std::path::{Path, PathBuf};
 
@@ -20,7 +21,7 @@ fn run_load_test(filename: &str, _filter: &FstFilter) {
     load_header(&mut reader);
 }
 
-fn load_header<R: BufRead + Seek>(reader: &mut FstReader<R>) -> Vec<String> {
+fn load_header<R: BufRead + Seek, H: BufRead + Seek>(reader: &mut FstReader<R, H>) -> Vec<String> {
     let mut is_real = Vec::new();
     let mut hierarchy = Vec::new();
     let foo = |entry: FstHierarchyEntry| {
@@ -64,6 +65,15 @@ fn load_verilator_incomplete() {
 
     let result = FstReader::open(std::io::BufReader::new(f));
     assert!(matches!(result, Err(ReaderError::MissingGeometry())));
+
+    let f = std::fs::File::open("fsts/verilator/verilator-incomplete.fst")
+        .unwrap_or_else(|_| panic!("Failed to open file"));
+    let h = std::fs::File::open("fsts/verilator/verilator-incomplete.fst.hier")
+        .unwrap_or_else(|_| panic!("Failed to open file"));
+    let mut reader =
+        FstReader::open_incomplete(std::io::BufReader::new(f), std::io::BufReader::new(h)).unwrap();
+
+    load_header(&mut reader);
 }
 
 #[test]

--- a/tests/fst_reader_tests.rs
+++ b/tests/fst_reader_tests.rs
@@ -7,7 +7,6 @@
 // and thus we cannot compare.
 
 use fst_reader::*;
-use std::collections::binary_heap::Iter;
 use std::io::{BufRead, Seek};
 use std::path::{Path, PathBuf};
 


### PR DESCRIPTION
This PR adds support for incomplete FST files with external hierarchy file, closing #3.

- A new variant was added to `HierarchyCompression` to allow for uncompressed hierarchies, as `.hier` files are uncompressed. `read_hierarchy_bytes` and `write_hierarchy_bytes` were updated accordingly.
- New `InputVariant`s were added to support incomplete FST files. For this, I added an additional type parameter `H` for the hierarchy input. To avoid breaking too much existing code, I set the default type for `H` to a dummy type `std::io::Cursor<Vec<u8>>` which implements `BufRead + Seek`. I also considered a different approach with a [`ReadHierarchy` trait and a custom type `InternalHierarchy`](https://github.com/Danacus/fst-reader/blob/type-madness/src/reader.rs#L10-L65) that implements this in case the hierarchy is internal in the FST file (which is the case for properly finalized FST files). But I decided on going for the simpler solution instead.
- I implemented `open_incomplete` to open incomplete FST files, while keeping the original `open_incomplete` for `FstReader<R, H>` where `H` is set to its default type. This should maintain compatibility with existing code, as code that uses `FstReader<R>` (without type parameter `H`) should still work.
- I added a function to reconstruct the geometry block from the hierarchy, as well as code to infer the start and end time from the data blocks, as this is what `libfst` does too. 
- I updated the tests and added a diff test for the incomplete FST file I added in #9.

Please let me know if you have any concerns or if you would like me to do something differently.