### PR TITLE
Remove dbg! statements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fst-reader"
-version = "0.13.1"
+version = "0.13.2"
 edition = "2021"
 authors = ["Kevin Laeufer <laeufer@cornell.edu>"]
 description = "FST wavedump format reader implemented in safe Rust. Formerly known as fst-native."

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -575,8 +575,6 @@ impl<R: Read + Seek> HeaderReader<R> {
                 Ok(tpe) => tpe,
             };
 
-            dbg!(&block_tpe);
-
             match block_tpe {
                 BlockType::Header => {
                     let (header, endian) = read_header(&mut self.input)?;

--- a/tests/fst_reader_tests.rs
+++ b/tests/fst_reader_tests.rs
@@ -104,11 +104,9 @@ fn find_fst_files(dir: &Path) -> Vec<PathBuf> {
 fn test_is_fst_file() {
     let fsts = find_fst_files(Path::new("fsts/"));
     for filename in fsts {
-        dbg!(&filename);
         let mut f = std::fs::File::open(filename.clone())
             .unwrap_or_else(|_| panic!("Failed to open {:?}", filename));
         let is_fst = is_fst_file(&mut f);
-        dbg!(is_fst);
         let should_be_fst = true;
         assert_eq!(
             is_fst, should_be_fst,


### PR DESCRIPTION
In #9 I accidentally committed some `dbg!` statements, and they showed up when I was using `wellen`. This PR removes them.

I'm sorry for forgetting to remove them earlier.