### PR TITLE
Removes println in reader

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -395,8 +395,6 @@ fn decompress_gz_in_chunks(
             miniz_oxide::MZFlush::None,
         );
 
-        println!("{res:?}\nremaining={remaining}");
-
         match res.status {
             Ok(status) => {
                 // move bytes that were not consumed to the start of the buffer and update the length


### PR DESCRIPTION
I guess this is a leftover from debugging. If not, could we put it behind some kind of feature?